### PR TITLE
Fix: board_image_cacheを追加して画像投稿機能を有効化#23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 .byebug_history
 
 /javascript/images
+/public/uploads
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem "rails-i18n"
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'pry-rails'
 
   gem 'rspec-rails', '~> 4.0.0'
   gem 'factory_bot_rails', '~> 5.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,11 @@ GEM
     parser (3.1.0.0)
       ast (~> 2.4.1)
     pg (1.3.0)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.6)
     puma (4.3.10)
       nio4r (~> 2.0)
@@ -328,6 +333,7 @@ DEPENDENCIES
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
   pg (>= 0.18, < 2.0)
+  pry-rails
   puma (~> 4.1)
   rails (~> 6.0.4, >= 6.0.4.4)
   rails-i18n

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -28,10 +28,10 @@ class BoardsController < ApplicationController
     @board.destroy!
     redirect_to mine_boards_path, success: '画像を削除しました！'
   end
-end
 
-private
+  private
 
-def board_params
-  params.required(:board).permit(:board_image)
+  def board_params
+    params.require(:board).permit(:board_image, :board_image_cache)
+  end
 end

--- a/app/views/boards/new.html.erb
+++ b/app/views/boards/new.html.erb
@@ -1,20 +1,20 @@
 <div class="board-new-page mt-auto">
-
   <%= render 'shared/navbar' %>
-
   <div class="board-form mt-0 row justify-content-center">
+
     <%= form_with model: @board, local: true do |f| %>
       <%= render 'shared/error_messages', object: f.object %>
       
       <div class="form-group">
-        <%= f.label '画像', class: 'text-white mb-3' %>
-        <%= f.file_field :board_image, class: 'form-control-file text-white bg-dark mb-3', id: 'board_image_upload' %>
+        <%= f.label :board_image, class: 'text-white mb-3' %>
+        <%= f.file_field :board_image, class: 'form-control-file text-white bg-dark mb-3' %>
+        <%= f.hidden_field :board_image_cache %>
       </div>
       
       <div class="submit-button">
         <%= f.submit '投稿する', class: 'btn btn-primary' %>
       </div>
-
     <% end %>
+
   </div>
 </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,9 +1,9 @@
 <% if object.errors.any? %>
   <div>
     <ul class="alert alert-danger list-unstyled">
-    <% object.errors.full_messages.each do |msg| %>
-      <li><%= msg %></li>
-    <% end %>
+      <% object.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
     </ul>
   </div>
 <% end %>


### PR DESCRIPTION
## 概要

画像投稿機能を修正しました。
画像登録を必須とするにあたって、`board_image_cache`が不可欠ということです。

