### PR TITLE
画像表示デザインの修正とmasonry適用 #33

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -17,6 +17,7 @@ require('jquery')
 
 require("src/board_image_preview");
 require("src/swipe");
+require("src/masonry")
 
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/app/javascript/src/masonry.js
+++ b/app/javascript/src/masonry.js
@@ -1,0 +1,12 @@
+$(function(){
+  var $container = $('.js-masonry-container');   //コンテナとなる要素を指定
+
+  $container.imagesLoaded(function(){ //imagesLoadedを使用し、画像が読み込みまれた段階でMasonryの関数を実行させる
+
+    $('.js-masonry-container').masonry({
+        itemSelector: '.js-masonry-item',
+        columnWidth: '.js-masonry-sizer',
+        percentPosition: true
+    });
+  });
+});

--- a/app/javascript/stylesheets/boards/mine.scss
+++ b/app/javascript/stylesheets/boards/mine.scss
@@ -1,35 +1,18 @@
-.my-board-index-page {
-  margin: auto 0;
-  height: 120%;
-  background-color: #343a40;
-}
-
-.trash-icon {
-  color: #4682b4;
-}
-
-.my-board {
-  width: 340px;
-  height: 340px;
-}
-
 .my-board-box {
   position: relative;
 }
-  
-.trash-box {
+
+.my-icon-star {
   position: absolute;
   top: 85%;
-  left: 55%;
+  left: 5%;
+  padding: 0 5px;
 }
 
-.no-board {
-  letter-spacing: 0.12em;
-}
-
-.object-fit {
-  background-color: gray;
-  width: 340px; height: 340px;
-  object-fit: contain;
+.my-icon-trash {
+  position: absolute;
+  top: 85%;
+  left: 80%;
+  padding: 0 5px;
 }
 

--- a/app/javascript/stylesheets/users/likes.scss
+++ b/app/javascript/stylesheets/users/likes.scss
@@ -2,11 +2,10 @@
   position: relative;
 }
 
-.icon-like {
+.icon-star {
   position: absolute;
   top: 85%;
-  left: 80%;
+  left: 5%;
   color: #ffa500;
-  background-color: #ffa500;
   padding: 0 5px;
 }

--- a/app/views/boards/mine.html.erb
+++ b/app/views/boards/mine.html.erb
@@ -10,7 +10,7 @@
         <% @boards.each do |board| %>
           <div class="js-masonry-item col-6 col-sm-4 col-lg-3" id="<% board.id %>">
             <div class="card mb-3 my-board-box">
-              <%= image_tag board.board_image.url, class: 'image-fluid' %>
+              <%= image_tag board.board_image.url, class: 'rounded' %>
               
               <div class="my-icon-star">
                 <i class="far fa-star fa-2x"></i>

--- a/app/views/boards/mine.html.erb
+++ b/app/views/boards/mine.html.erb
@@ -2,27 +2,31 @@
   <%= render "shared/navbar" %>
   <div class="container-fluid">
 
-    <div class="row mt-3">
-      <% @boards.each do |board| %>
-        <div class="col-sm-3" id="<% board.id %>">
-          <div class="card my-board-box mb-3">
-            <%= image_tag board.board_image.url, class: 'image-fluid' %>
-            
-            <div class="my-icon-star">
-              <i class="far fa-star fa-2x"></i>
-              <%= liked_count_of(board) %>
-            </div> 
-            
-            <div class="my-icon-trash">
-              <%= link_to board_path(board), method: :delete, data: { confirm: "画像を削除しますか？" } do %>
-                <i class="far fa-trash-alt fa-2x trash-icon"></i>
-              <% end %>
+    <div class="js-masonry-container">
+
+      <div class="js-masonry-sizer col-6 col-sm-4 col-lg-3"></div>
+
+      <div class="row mt-3">
+        <% @boards.each do |board| %>
+          <div class="js-masonry-item col-6 col-sm-4 col-lg-3" id="<% board.id %>">
+            <div class="card mb-3 my-board-box">
+              <%= image_tag board.board_image.url, class: 'image-fluid' %>
+              
+              <div class="my-icon-star">
+                <i class="far fa-star fa-2x"></i>
+                <%= liked_count_of(board) %>
+              </div> 
+              
+              <div class="my-icon-trash">
+                <%= link_to board_path(board), method: :delete, data: { confirm: "画像を削除しますか？" } do %>
+                  <i class="far fa-trash-alt fa-2x trash-icon"></i>
+                <% end %>
+              </div>
             </div>
           </div>
-        </div>
-      <% end %>
-    </div>
-  </div>
-  
+        <% end %>
+      </div>
+    </div> <!-- .grid-index -->
+  </div> 
     <div class="">画像は以上です</div>
 </div>

--- a/app/views/boards/mine.html.erb
+++ b/app/views/boards/mine.html.erb
@@ -1,23 +1,28 @@
 <div class="my-board-index-page">
   <%= render "shared/navbar" %>
+  <div class="container-fluid">
 
-  <div class="my-cards mt-3">
-
-    <% @boards.each do |board| %>
-      <div class="my-card bg-dark my-board-box" id="<% board.id %>">
-        <%= image_tag board.board_image.url, class: 'my-board-img img-fluid rounded d-block mx-auto my-board object-fit' %>
-        
-        <div class="icon-box text-center bg-dark">
-          <i class="far fa-star fa-2x"></i>
-          <%= liked_count_of(board) %>
-          
-          <%= link_to board_path(board), class: 'trash', method: :delete, data: { confirm: "画像を削除しますか？" } do %>
-            <i class="far fa-trash-alt fa-2x trash-icon"></i>
-          <% end %>
-        </div> 
-      </div>
-    <% end %>
-
+    <div class="row mt-3">
+      <% @boards.each do |board| %>
+        <div class="col-sm-3" id="<% board.id %>">
+          <div class="card my-board-box mb-3">
+            <%= image_tag board.board_image.url, class: 'image-fluid' %>
+            
+            <div class="my-icon-star">
+              <i class="far fa-star fa-2x"></i>
+              <%= liked_count_of(board) %>
+            </div> 
+            
+            <div class="my-icon-trash">
+              <%= link_to board_path(board), method: :delete, data: { confirm: "画像を削除しますか？" } do %>
+                <i class="far fa-trash-alt fa-2x trash-icon"></i>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
   </div>
-    <div class="no-board text-white text-center bg-dark">画像は以上です</div>
+  
+    <div class="">画像は以上です</div>
 </div>

--- a/app/views/boards/mine.html.erb
+++ b/app/views/boards/mine.html.erb
@@ -26,7 +26,7 @@
           </div>
         <% end %>
       </div>
-    </div> <!-- .grid-index -->
+    </div> <!-- .js-masonry-container -->
   </div> 
-    <div class="">画像は以上です</div>
+    <div class="text-center mt-3">画像は以上です</div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,9 @@
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+
+    <script src="https://unpkg.com/imagesloaded@4/imagesloaded.pkgd.min.js"></script>
+    <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
   </head>
 
   <body>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -11,7 +11,7 @@
   <div class="collapse navbar-collapse" id="navbarNav">
     <ul class="navbar-nav">
       <li class="nav-item active">
-        <%= link_to 'Top', root_path, class: 'nav-link' %>
+        <%= link_to 'Top', root_path, class: 'nav-link', 'data-turbolinks': false %>
       </li>
 
       <li class="navbar-item">
@@ -24,11 +24,11 @@
         </li>
 
         <li class="nav-item">
-          <%= link_to 'My collection', mine_boards_path, class: 'nav-link' %>
+          <%= link_to 'My collection', mine_boards_path, class: 'nav-link', 'data-turbolinks': false %>
         </li>
 
         <li class="nav-item">
-          <%= link_to 'Favorite', likes_users_path, class: 'nav-link' %>
+          <%= link_to 'Favorite', likes_users_path, class: 'nav-link', 'data-turbolinks': false %>
         </li>
         
         <li class="nav-item">

--- a/app/views/users/likes.html.erb
+++ b/app/views/users/likes.html.erb
@@ -5,9 +5,9 @@
   <div class="row mt-3">
     <% @like_boards.each do |board| %>
       <div class="col-sm-3">
-        <div class="card board-box">
+        <div class="card board-box mb-3">
           <%= image_tag board.board_image.url, class: 'image-fluid' %>
-          <div class="icon-like">
+          <div class="icon-star">
             <i class="far fa-star fa-2x"></i>
             <%= liked_count_of(board) %>
           </div>

--- a/app/views/users/likes.html.erb
+++ b/app/views/users/likes.html.erb
@@ -1,21 +1,23 @@
 <div class="like-board-index-page">
   <%= render 'shared/navbar' %>
   <div class="container-fluid">
-
-  <div class="row mt-3">
-    <% @like_boards.each do |board| %>
-      <div class="col-sm-3">
-        <div class="card board-box mb-3">
-          <%= image_tag board.board_image.url, class: 'image-fluid' %>
-          <div class="icon-star">
-            <i class="far fa-star fa-2x"></i>
-            <%= liked_count_of(board) %>
+  
+    <div class="js-masonry-container">
+      <div class="js-masonry-sizer col-6 col-sm-4 col-lg-3"></div>
+      <div class="row mt-3">
+        <% @like_boards.each do |board| %>
+          <div class="js-masonry-item col-6 col-sm-4 col-lg-3">
+            <div class="card board-box mb-3">
+              <%= image_tag board.board_image.url, class: 'image-fluid' %>
+              <div class="icon-star">
+                <i class="far fa-star fa-2x"></i>
+                <%= liked_count_of(board) %>
+              </div>
+            </div>
           </div>
-        </div>
+        <% end %>
       </div>
-    <% end %>
-  </div>
-
+    </div> <!-- .js-masonry-container -->
     <p class="text-center mt-3">画像は以上です</p>
   </div>
 </div>

--- a/app/views/users/likes.html.erb
+++ b/app/views/users/likes.html.erb
@@ -8,7 +8,7 @@
         <% @like_boards.each do |board| %>
           <div class="js-masonry-item col-6 col-sm-4 col-lg-3">
             <div class="card board-box mb-3">
-              <%= image_tag board.board_image.url, class: 'image-fluid' %>
+              <%= image_tag board.board_image.url, class: 'rounded' %>
               <div class="icon-star">
                 <i class="far fa-star fa-2x"></i>
                 <%= liked_count_of(board) %>


### PR DESCRIPTION
## 概要

以下を修正しました。
- 画像とアイコンの相対的位置関係
- 「画像は以上です」の文言を中央に寄せました

以下を追加しました。
- CDN で`imagesLoaded`, `masonry`の導入
- `users/likes`, `boards/mine`の画像を`masonry`で表示

