### PR TITLE
画像表示順序を変更しました #35

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -2,7 +2,7 @@ class BoardsController < ApplicationController
   skip_before_action :check_logged_in, only: :index
 
   def index
-    @boards = Board.where.not(user_id: current_user.id)
+    @boards = Board.where.not(user_id: current_user.id).order(created_at: :desc)
   end
 
   def mine

--- a/app/javascript/stylesheets/boards/index.scss
+++ b/app/javascript/stylesheets/boards/index.scss
@@ -103,6 +103,12 @@
   }
 }
 
+.index-object-fit {
+  background-color: #343a40;
+  width: 340px; height: 340px;
+  object-fit: contain;
+}
+
 .fa-heart {
   color: #FFACE4;
 }

--- a/app/javascript/stylesheets/boards/mine.scss
+++ b/app/javascript/stylesheets/boards/mine.scss
@@ -4,15 +4,15 @@
 
 .my-icon-star {
   position: absolute;
-  top: 85%;
+  top: 80%;
   left: 5%;
   padding: 0 5px;
 }
 
 .my-icon-trash {
   position: absolute;
-  top: 85%;
-  left: 80%;
+  top: 80%;
+  left: 75%;
   padding: 0 5px;
 }
 

--- a/app/javascript/stylesheets/boards/new.scss
+++ b/app/javascript/stylesheets/boards/new.scss
@@ -4,8 +4,8 @@
   height: 100%;
 }
 
-.object-fit {
-  background-color: gray;
+.new-object-fit {
+  background-color: #343a40;
   width: 340px; height: 340px;
   object-fit: contain;
 }

--- a/app/javascript/stylesheets/users/likes.scss
+++ b/app/javascript/stylesheets/users/likes.scss
@@ -4,7 +4,7 @@
 
 .icon-star {
   position: absolute;
-  top: 85%;
+  top: 80%;
   left: 5%;
   color: #ffa500;
   padding: 0 5px;

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   has_many :react_boards, through: :reactions, source: :board
 
   def favorite_boards
-    reactions.where(status: 'like').order(created_at: :desc)
+    reactions.where(status: 'like').order(updated_at: :desc)
   end
 
   class << self

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   has_many :react_boards, through: :reactions, source: :board
 
   def favorite_boards
-    reactions.where(status: 'like')
+    reactions.where(status: 'like').order(created_at: :desc)
   end
 
   class << self

--- a/app/views/boards/index.html.erb
+++ b/app/views/boards/index.html.erb
@@ -10,7 +10,7 @@
     <div class="swipe--cards">
       <% @boards.each do |board| %>
         <div class="swipe--card" id="<%= board.id %>">
-          <%= image_tag board.board_image.url, class: 'board-img object-fit' %>
+          <%= image_tag board.board_image.url, class: 'board-img index-object-fit' %>
         </div>
       <% end %>
 

--- a/app/views/boards/new.html.erb
+++ b/app/views/boards/new.html.erb
@@ -7,7 +7,7 @@
       
       <div class="form-group row justify-content-center">
         <%= f.label :board_image, class: 'text-white mb-3' do %>
-          <%= image_pack_tag 'media/images/sample.jpg', class: 'js-default_image object-fit' %>
+          <%= image_pack_tag 'media/images/sample.jpg', class: 'rounded js-default_image new-object-fit' %>
           <%= f.file_field :board_image, class: 'form-control-file text-white bg-dark mb-3 mt-3 d-none js-uploader' %>
           <%= f.hidden_field :board_image_cache %>
         <% end %>


### PR DESCRIPTION
## 概要

以下の修正を行いました。
- boards/index（スワイプページ）の画像表示順序を`created_at`降順に修正
- users/likesの画像表示順序を`Reaction`の`update_at`降順に修正
- 画像表示の際のアイコンの位置を微調整

## チェックリスト

- [x] Lint のチェックをパスした
