### PR TITLE
Add arrow upload heic#37

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,9 @@ gem "mini_magick"
 # Translated into Japanese
 gem "rails-i18n"
 
+# 投稿画像サイズの制限
+gem 'file_validators'
+
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,9 @@ GEM
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
     ffi (1.15.5)
+    file_validators (3.0.0)
+      activemodel (>= 3.2)
+      mime-types (>= 1.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     hashie (5.0.0)
@@ -149,6 +152,9 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     minitest (5.15.0)
@@ -327,6 +333,7 @@ DEPENDENCIES
   carrierwave (~> 2.0)
   dotenv-rails
   factory_bot_rails (~> 5.2.0)
+  file_validators
   jbuilder (~> 2.7)
   listen (~> 3.2)
   mini_magick

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -5,4 +5,5 @@ class Board < ApplicationRecord
   mount_uploader :board_image, BoardImageUploader
 
   validates :board_image, presence: true
+  validates :board_image, file_size: { less_than: 20.megabytes }
 end

--- a/app/uploaders/board_image_uploader.rb
+++ b/app/uploaders/board_image_uploader.rb
@@ -39,6 +39,10 @@ class BoardImageUploader < CarrierWave::Uploader::Base
     %w[jpg jpeg gif png]
   end
 
+  def size_range
+    1..20.megabytes
+  end
+
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.
   # def filename

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,6 +1,6 @@
 <% if object.errors.any? %>
   <div>
-    <ul class="alert alert-danger list-unstyled">
+    <ul class="alert alert-danger list-unstyled text-center">
       <% object.errors.full_messages.each do |msg| %>
         <li><%= msg %></li>
       <% end %>

--- a/config/locales/carrierwave/ja.yml
+++ b/config/locales/carrierwave/ja.yml
@@ -1,0 +1,14 @@
+ja:
+  errors:
+    messages:
+      carrierwave_processing_error: 処理できませんでした
+      carrierwave_integrity_error: は許可されていないファイルタイプです
+      carrierwave_download_error: はダウンロードできません
+      extension_whitelist_error: "%{extension}ファイルのアップロードは許可されていません。アップロードできるファイルタイプ: %{allowed_types}"
+      extension_blacklist_error: "%{extension}ファイルのアップロードは許可されていません。アップロードできないファイルタイプ: %{prohibited_types}"
+      content_type_whitelist_error: "%{content_type}ファイルのアップロードは許可されていません。アップロードできるファイルタイプ: %{allowed_types}"
+      content_type_blacklist_error: "%{content_type}ファイルのアップロードは許可されていません"
+      rmagick_processing_error: "rmagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
+      mini_magick_processing_error: "MiniMagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
+      min_size_error: "を%{min_size}以上のサイズにしてください"
+      max_size_error: "を%{max_size}以下のサイズにしてください"


### PR DESCRIPTION
## 概要
以下の変更を行いました。`.heic`の対応はできていません。
※iphoneからmacにエアードロップして投稿した時のみのエラーのため、解決を急ぐことをやめました。

- carrierwaveのエラーメッセージを日本語化（.heic 投稿エラーも出力できます）
- `gem, file_validator`による、画像サイズの上限付与

## 確認方法

1. Gem を追加したので `bundle install` を実行してください

